### PR TITLE
feat(chart): tekton-git ExternalSecret uses multi-cluster toggle

### DIFF
--- a/charts/leartech-ai-classifier/templates/externalsecret-tekton-git.yaml
+++ b/charts/leartech-ai-classifier/templates/externalsecret-tekton-git.yaml
@@ -1,20 +1,33 @@
-{{- if or .Values.eval.enabled .Values.training.enabled }}
-# Syncs tekton-git credentials for CronJob scripts that need to
-# clone private repos (eval + train need leartech-llm-training-data)
+{{- /*
+Syncs tekton-git credentials for CronJob scripts that need to clone
+private repos (eval + train need leartech-llm-training-data) AND for
+any service in the same namespace that references tekton-git via the
+standard tekton.dev/git-0 annotation.
+
+Multi-cluster pattern (auth-service-style toggle): each cluster's
+GitOps configs/leartech-ai-classifier.yaml flips externalSecrets.gcp.enabled
+or externalSecrets.azure.enabled to render the right backend block.
+
+Long-term direction: every chart that needs tekton-git uses this
+pattern; the ExternalSecret has a single owner per cluster and other
+charts reference it by name.
+*/}}
+{{- if and (or .Values.eval.enabled .Values.training.enabled) (or .Values.externalSecrets.gcp.enabled .Values.externalSecrets.azure.enabled) }}
+{{- if .Values.externalSecrets.gcp.enabled }}
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: tekton-git
 spec:
   backendType: gcpSecretsManager
-  projectId: product-first
+  projectId: {{ .Values.externalSecrets.gcp.projectId | default "product-first" }}
   data:
   - name: password
-    key: tf-jx-usable-bird-jx-pipeline-user
+    key: {{ .Values.externalSecrets.gcp.tektonGitKey | default "tf-jx-usable-bird-jx-pipeline-user" }}
     property: token
     version: latest
   - name: username
-    key: tf-jx-usable-bird-jx-pipeline-user
+    key: {{ .Values.externalSecrets.gcp.tektonGitKey | default "tf-jx-usable-bird-jx-pipeline-user" }}
     property: username
     version: latest
   template:
@@ -22,4 +35,27 @@ spec:
       annotations:
         tekton.dev/git-0: "https://github.com"
     type: kubernetes.io/basic-auth
+{{- end }}
+{{- if .Values.externalSecrets.azure.enabled }}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: tekton-git
+spec:
+  backendType: vault
+  vaultMountPoint: {{ .Values.externalSecrets.azure.vaultMountPoint | default "kubernetes" }}
+  vaultRole: {{ .Values.externalSecrets.azure.vaultRole | default "jx-vault" }}
+  data:
+  - name: password
+    key: {{ .Values.externalSecrets.azure.tektonGitKey | default "secret/data/jx/pipelineUser" }}
+    property: password
+  - name: username
+    key: {{ .Values.externalSecrets.azure.tektonGitKey | default "secret/data/jx/pipelineUser" }}
+    property: username
+  template:
+    metadata:
+      annotations:
+        tekton.dev/git-0: "https://github.com"
+    type: kubernetes.io/basic-auth
+{{- end }}
 {{- end }}

--- a/charts/leartech-ai-classifier/values.yaml
+++ b/charts/leartech-ai-classifier/values.yaml
@@ -58,6 +58,24 @@ training:
   github:
     secretName: tekton-git
 
+# Multi-cluster ExternalSecret toggle (auth-service pattern). Each cluster's
+# configs/leartech-ai-classifier.yaml flips externalSecrets.gcp.enabled or
+# externalSecrets.azure.enabled. Default false on both so an unconfigured
+# install doesn't try to materialise tekton-git via the wrong backend.
+#
+# Pre-2026-05-07 the chart hardcoded gcpSecretsManager and silently
+# failed on AZ for ~3 days. This toggle is the durable fix.
+externalSecrets:
+  gcp:
+    enabled: false
+    projectId: product-first
+    tektonGitKey: tf-jx-usable-bird-jx-pipeline-user
+  azure:
+    enabled: false
+    vaultMountPoint: kubernetes
+    vaultRole: jx-vault
+    tektonGitKey: secret/data/jx/pipelineUser
+
 jxRequirements:
   ingress:
     domain: ""


### PR DESCRIPTION
Refactors externalsecret-tekton-git.yaml to use the auth-service-style toggle pattern (externalSecrets.{gcp,azure}.enabled). The pre-2026-05-07 hardcoded GSM block silently failed on AZ Modern-Burro for ~3 days and also blocked other charts from materialising their own tekton-git via Helm release-ownership conflicts.

Companion PRs in jx-build-cluster-gsm and jx-build-cluster-akv add the configs/leartech-ai-classifier.yaml that flips the right toggle per cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)