### PR TITLE
feat(secrets): tektonGit.create toggle (cluster-owned tekton-git)

### DIFF
--- a/charts/leartech-ai-classifier/templates/externalsecret-tekton-git.yaml
+++ b/charts/leartech-ai-classifier/templates/externalsecret-tekton-git.yaml
@@ -12,7 +12,7 @@ Long-term direction: every chart that needs tekton-git uses this
 pattern; the ExternalSecret has a single owner per cluster and other
 charts reference it by name.
 */}}
-{{- if and (or .Values.eval.enabled .Values.training.enabled) (or .Values.externalSecrets.gcp.enabled .Values.externalSecrets.azure.enabled) }}
+{{- if and (.Values.tektonGit.create) (or .Values.eval.enabled .Values.training.enabled) (or .Values.externalSecrets.gcp.enabled .Values.externalSecrets.azure.enabled) }}
 {{- if .Values.externalSecrets.gcp.enabled }}
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret

--- a/charts/leartech-ai-classifier/values.yaml
+++ b/charts/leartech-ai-classifier/values.yaml
@@ -80,3 +80,9 @@ jxRequirements:
   ingress:
     domain: ""
     namespaceSubDomain: ""
+
+# Single-owner-per-cluster for the shared tekton-git secret. Default true keeps
+# backward-compat; set false in a cluster's configs to let the CLUSTER own + replicate
+# tekton-git (no chart owns it) and avoid multi-chart ownership collisions.
+tektonGit:
+  create: true


### PR DESCRIPTION
Adds `tektonGit.create` (default true) so a cluster can opt this chart out of owning the shared tekton-git secret — enabling a single cluster-owned ESO + replication. No behaviour change by default; applies to both clusters.